### PR TITLE
#28 srcフォルダがないとJS/CSSのデバッグができないので同梱

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -15,6 +15,7 @@
 /gulpfile.js export-ignore
 /stylelint.config.js export-ignore
 /webpack.config.js export-ignore
+/doc export-ignore
 
 # Development files
 /.editorconfig export-ignore
@@ -41,7 +42,6 @@
 /artifacts export-ignore
 /doc export-ignore
 /scripts export-ignore
-/src export-ignore
 /assets/test export-ignore
 /.gitattributes export-ignore
 


### PR DESCRIPTION
composerで配布したときに利用者側がデバッグできないのでsrcを含める